### PR TITLE
Memory leak with _responseData instance variable of EGOImageLoadConnection

### DIFF
--- a/EGOImageLoader/EGOImageLoadConnection.m
+++ b/EGOImageLoader/EGOImageLoadConnection.m
@@ -90,6 +90,7 @@
 	self.delegate = nil;
 	[_connection release];
 	[_imageURL release];
+  [_responseData release];
 	[super dealloc];
 }
 


### PR DESCRIPTION
Hi guys,

My application was reporting a memory leak on Instruments until I finally tracked it down to the _responseData variable of EGOImageLoadConnection. It was not being released.

This commit just releases that variable on the dealloc method. It fixed the memory leak I had in my application.

Thanks for writing such a great library!
