### PR TITLE
Switched hash for an implementation of MD5 cache to great unique URL keys

### DIFF
--- a/Demo/EGOImageLoadingDemo.xcodeproj/project.pbxproj
+++ b/Demo/EGOImageLoadingDemo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		28BBA36B10C62E3300081AB5 /* EGOImageLoadConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 28BBA36A10C62E3300081AB5 /* EGOImageLoadConnection.m */; };
 		28C286E10D94DF7D0034E888 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C286E00D94DF7D0034E888 /* RootViewController.m */; };
 		28F335F11007B36200424DE2 /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* RootViewController.xib */; };
+		66FE1FE81416232400D3295C /* NSString+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FE1FE71416232400D3295C /* NSString+MD5.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,8 @@
 		28C286E00D94DF7D0034E888 /* RootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootViewController.m; sourceTree = "<group>"; };
 		28F335F01007B36200424DE2 /* RootViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RootViewController.xib; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		66FE1FE61416232400D3295C /* NSString+MD5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+MD5.h"; sourceTree = "<group>"; };
+		66FE1FE71416232400D3295C /* NSString+MD5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MD5.m"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* EGOImageLoadingDemo-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "EGOImageLoadingDemo-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -131,6 +134,8 @@
 				2826AB15108D4295007FBD1D /* EGOImageLoader.m */,
 				28BBA36910C62E3300081AB5 /* EGOImageLoadConnection.h */,
 				28BBA36A10C62E3300081AB5 /* EGOImageLoadConnection.m */,
+				66FE1FE61416232400D3295C /* NSString+MD5.h */,
+				66FE1FE71416232400D3295C /* NSString+MD5.m */,
 			);
 			name = EGOImageLoader;
 			path = ../EGOImageLoader;
@@ -264,6 +269,7 @@
 				2826AB50108D4295007FBD1D /* EGOImageView.m in Sources */,
 				2826AB8E108D5160007FBD1D /* ExampleCell.m in Sources */,
 				28BBA36B10C62E3300081AB5 /* EGOImageLoadConnection.m in Sources */,
+				66FE1FE81416232400D3295C /* NSString+MD5.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EGOImageLoader/EGOImageLoader.m
+++ b/EGOImageLoader/EGOImageLoader.m
@@ -27,14 +27,15 @@
 #import "EGOImageLoader.h"
 #import "EGOImageLoadConnection.h"
 #import "EGOCache.h"
+#import "NSString+MD5.h"
 
 static EGOImageLoader* __imageLoader;
 
 inline static NSString* keyForURL(NSURL* url, NSString* style) {
 	if(style) {
-		return [NSString stringWithFormat:@"EGOImageLoader-%u-%u", [[url description] hash], [style hash]];
+		return [NSString stringWithFormat:@"EGOImageLoader-%u-%u", [[url description] md5Hash], [style md5Hash]];
 	} else {
-		return [NSString stringWithFormat:@"EGOImageLoader-%u", [[url description] hash]];
+		return [NSString stringWithFormat:@"EGOImageLoader-%u", [[url description] md5Hash]];
 	}
 }
 

--- a/EGOImageLoader/EGOImageLoader.m
+++ b/EGOImageLoader/EGOImageLoader.m
@@ -33,9 +33,9 @@ static EGOImageLoader* __imageLoader;
 
 inline static NSString* keyForURL(NSURL* url, NSString* style) {
 	if(style) {
-		return [NSString stringWithFormat:@"EGOImageLoader-%u-%u", [[url description] md5Hash], [style md5Hash]];
+		return [NSString stringWithFormat:@"EGOImageLoader-%@-%@", [[url description] md5Hash], [style md5Hash]];
 	} else {
-		return [NSString stringWithFormat:@"EGOImageLoader-%u", [[url description] md5Hash]];
+		return [NSString stringWithFormat:@"EGOImageLoader-%@", [[url description] md5Hash]];
 	}
 }
 

--- a/EGOImageLoader/NSString+MD5.h
+++ b/EGOImageLoader/NSString+MD5.h
@@ -1,0 +1,12 @@
+//
+//  NSString+MD5.h
+//  EGOImageLoading
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (MD5)
+
+- (NSString *)md5Hash;
+
+@end

--- a/EGOImageLoader/NSString+MD5.m
+++ b/EGOImageLoader/NSString+MD5.m
@@ -1,0 +1,25 @@
+//
+//  NSString+MD5.m
+//  EGOImageLoading
+//
+
+#import "NSString+MD5.h"
+#import <CommonCrypto/CommonDigest.h>
+
+@implementation NSString (MD5)
+
+- (NSString *)md5Hash {
+	
+	const char *cStr = [self UTF8String];
+	unsigned char result[16];
+	CC_MD5( cStr, strlen(cStr), result );
+	return [NSString stringWithFormat:
+			@"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+			result[0], result[1], result[2], result[3], 
+			result[4], result[5], result[6], result[7],
+			result[8], result[9], result[10], result[11],
+			result[12], result[13], result[14], result[15]
+			];
+}
+
+@end


### PR DESCRIPTION
I ran into a problem where the `inline static NSString* keyForURL(NSURL* url, NSString* style)` method was not returning a unique URL key for my images.

I noticed it when 3 different images with different URLs in one app all produced the same URL key using `hash` therefore the wrong image was loaded from the cache.

I have added an NSString category (NSString+MD5) with a single method, `- (NSString *)md5Hash;` that returns a MD5 hash of a string. I have swapped the origin use for `hash` in EGOImageLoader.m for this new method.

I've done some testing and it seems to have solved my problem.

I haven't included any credit in the header of the NSString category as I found it on Stack Overflow where no credit was given.
