### PR TITLE
Nilling out the delegate to avoid crashes in tables with EGOImageViews in

### DIFF
--- a/EGOImageView/EGOImageView.m
+++ b/EGOImageView/EGOImageView.m
@@ -104,6 +104,7 @@
 #pragma mark -
 - (void)dealloc {
 	[[EGOImageLoader sharedImageLoader] removeObserver:self];
+	self.delegate = nil;
 	self.imageURL = nil;
 	self.placeholderImage = nil;
     [super dealloc];


### PR DESCRIPTION
Nilling out the delegate to avoid crashes in tables with EGOImageViews in each cell in circumstances of slow connections where the view controller with the table could be deallocated and notified afterwards about images that finished downloading.
